### PR TITLE
[#4] chainPlot()

### DIFF
--- a/src/StoryFactory.sol
+++ b/src/StoryFactory.sol
@@ -158,10 +158,11 @@ contract StoryFactory {
             require(block.timestamp <= s.lastPlotTime + 72 hours, "Deadline passed");
         }
 
+        uint256 plotIndex = s.plotCount; // genesis = 0, so first chain = 1
         s.plotCount++;
         s.lastPlotTime = block.timestamp;
 
-        emit PlotChained(storylineId, s.plotCount, msg.sender, contentCID, contentHash);
+        emit PlotChained(storylineId, plotIndex, msg.sender, contentCID, contentHash);
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Implements `chainPlot(storylineId, contentCID, contentHash)` with all four validations:
1. `msg.sender == writer` (access control)
2. CID length 46-100 bytes (format guard)
3. `!sunset` (not sunset)
4. `block.timestamp <= lastPlotTime + 72 hours` (deadline, if enabled)

Updates plotCount and lastPlotTime, emits PlotChained.

Fixes #4

## Test plan
- [x] `forge build` succeeds
- [ ] Unit tests (contracts#6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)