### PR TITLE
[#32] Fix D2: expect revert on empty royalty claim

### DIFF
--- a/script/E2ETest.s.sol
+++ b/script/E2ETest.s.sol
@@ -391,13 +391,13 @@ contract E2ETest is Script {
         // Serialize royalty results
         vm.serializeUint(resultsJson, "royaltiesClaimed", royaltyClaimed);
 
-        // D2: Claim again - should return 0
-        balBefore = PL_TEST.balanceOf(deployer);
-        BOND.claimRoyalties(address(PL_TEST));
-        uint256 royaltyClaimed2 = PL_TEST.balanceOf(deployer) - balBefore;
-        require(royaltyClaimed2 == 0, "D2: double-claim should return 0");
-        console.log("[D2] Claim royalties again (empty)     PASS  amount=%d", royaltyClaimed2);
-        scenariosPassed++;
+        // D2: Claim again - should revert with MCV2_Royalty__NothingToClaim()
+        try BOND.claimRoyalties(address(PL_TEST)) {
+            revert("D2: should have reverted on empty claim");
+        } catch {
+            console.log("[D2] Empty claim reverts               PASS  (MCV2_Royalty__NothingToClaim)");
+            scenariosPassed++;
+        }
     }
 
     // ===================================================================


### PR DESCRIPTION
## Summary
- Convert D2 test from zero-balance-check to try/catch revert expectation
- MCV2_Bond.claimRoyalties() reverts with `MCV2_Royalty__NothingToClaim()` when there are no royalties, rather than returning silently

## Test plan
- [x] All 28 unit tests pass
- [x] `forge fmt --check` clean
- [ ] E2E mainnet run completes past Group D without revert

Fixes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)