### PR TITLE
[#34] Add vm.prank for E8/E9 chainPlot CID validation

### DIFF
--- a/script/E2ETest.s.sol
+++ b/script/E2ETest.s.sol
@@ -476,7 +476,8 @@ contract E2ETest is Script {
             scenariosPassed++;
         }
 
-        // E8: chainPlot with CID < 46 chars
+        // E8: chainPlot with CID < 46 chars (prank as deployer to pass writer check)
+        vm.prank(deployer);
         try FACTORY.chainPlot(idA1, "Test", "QmShortCID1234567890123456789012345678901234", HASH_A) {
             revert("E8: should have reverted");
         } catch Error(string memory reason) {
@@ -485,7 +486,8 @@ contract E2ETest is Script {
             scenariosPassed++;
         }
 
-        // E9: chainPlot with CID > 100 chars
+        // E9: chainPlot with CID > 100 chars (prank as deployer to pass writer check)
+        vm.prank(deployer);
         try FACTORY.chainPlot(
             idA1,
             "Test",


### PR DESCRIPTION
## Summary
- Add `vm.prank(deployer)` before E8 and E9 `chainPlot()` calls
- Group E runs outside `vm.broadcast()`, so msg.sender is the script contract — writer check fires before CID validation
- Prank ensures writer check passes so the "Invalid CID" revert is actually tested

## Test plan
- [x] All 28 unit tests pass
- [x] `forge fmt --check` clean
- [ ] E2E mainnet run completes past Group E without wrong revert reason

Fixes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)