### PR TITLE
[#39] Drain pending royalties before D2 revert test

### DIFF
--- a/script/E2ETestReverts.s.sol
+++ b/script/E2ETestReverts.s.sol
@@ -36,6 +36,11 @@ contract E2ETestReverts is Script {
         // ===== Group D2: Empty royalty claim =====
         console.log("--- Group D: Royalties (reverts) ---");
 
+        // Drain any pending royalties first (F5 buy/sell may have generated new ones)
+        vm.prank(deployer);
+        try BOND.claimRoyalties(address(PL_TEST)) {} catch {}
+
+        // Now the second claim should revert with NothingToClaim
         vm.prank(deployer);
         try BOND.claimRoyalties(address(PL_TEST)) {
             revert("D2: should have reverted on empty claim");


### PR DESCRIPTION
## Summary
- Drain any pending royalties before D2 empty-claim revert assertion
- F5 buy/sell in the broadcast script generates new royalties after D1 claims, so the revert script's D2 test needs to drain first

## Test plan
- [x] Build passes
- [x] Verified on mainnet: revert script passes all 11 scenarios with this fix

Fixes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)