### PR TITLE
[#41] Royalty reduction, remove sunset, struct optimization

### DIFF
--- a/script/E2ETest.s.sol
+++ b/script/E2ETest.s.sol
@@ -141,7 +141,7 @@ contract E2ETest is Script {
 
         // A1: Create storyline WITH deadline, chain 3 plots
         idA1 = FACTORY.createStoryline{value: creationFee}("E2E Story Alpha", CID_46, HASH_A, true);
-        (address w1, address t1, uint256 pc1,, bool hd1,) = FACTORY.storylines(idA1);
+        (address w1, address t1, uint24 pc1,, bool hd1) = FACTORY.storylines(idA1);
         require(w1 == deployer, "A1: writer mismatch");
         require(t1 != address(0), "A1: token is zero");
         require(pc1 == 1, "A1: plotCount != 1");
@@ -153,7 +153,7 @@ contract E2ETest is Script {
         FACTORY.chainPlot(idA1, "Chapter 2", CID_46, HASH_B);
         FACTORY.chainPlot(idA1, "Chapter 3", CID_46, HASH_C);
         FACTORY.chainPlot(idA1, "Chapter 4", CID_46, HASH_D);
-        (,, uint256 pc1b,,,) = FACTORY.storylines(idA1);
+        (,, uint24 pc1b,,) = FACTORY.storylines(idA1);
         require(pc1b == 4, "A1: plotCount != 4 after chaining");
         console.log("[A1] Chain plots 1/3, 2/3, 3/3         PASS  plotCount=%d", pc1b);
         scenariosPassed += 2; // A1 create + A1 chain
@@ -168,14 +168,14 @@ contract E2ETest is Script {
 
         // A2: Create storyline WITHOUT deadline, chain 1 plot
         idA2 = FACTORY.createStoryline{value: creationFee}("E2E Story Beta", CID_46, HASH_A, false);
-        (address w2, address t2, uint256 pc2,, bool hd2,) = FACTORY.storylines(idA2);
+        (address w2, address t2, uint24 pc2,, bool hd2) = FACTORY.storylines(idA2);
         require(w2 == deployer, "A2: writer mismatch");
         require(t2 != address(0), "A2: token is zero");
         require(pc2 == 1, "A2: plotCount != 1");
         require(hd2 == false, "A2: hasDeadline should be false");
 
         FACTORY.chainPlot(idA2, "Beta Chapter 2", CID_46, HASH_B);
-        (,, uint256 pc2b,,,) = FACTORY.storylines(idA2);
+        (,, uint24 pc2b,,) = FACTORY.storylines(idA2);
         require(pc2b == 2, "A2: plotCount != 2");
         console.log("[A2] Create storyline no deadline       PASS  storylineId=%d  plotCount=%d", idA2, pc2b);
         scenariosPassed++;
@@ -190,7 +190,7 @@ contract E2ETest is Script {
 
         // A3: Same wallet creates 2nd storyline (3rd total)
         idA3 = FACTORY.createStoryline{value: creationFee}("E2E Story Gamma", CID_46, HASH_A, false);
-        (address w3, address t3,,,,) = FACTORY.storylines(idA3);
+        (address w3, address t3,,,) = FACTORY.storylines(idA3);
         require(w3 == deployer, "A3: writer mismatch");
         require(t3 != address(0), "A3: token is zero");
         require(t3 != t1 && t3 != t2, "A3: token not unique");
@@ -409,13 +409,13 @@ contract E2ETest is Script {
 
         // F4: chainPlot with empty title (title not validated in chainPlot) — use F1's storyline
         FACTORY.chainPlot(idF1, "", CID_46, HASH_B);
-        (,, uint256 pc,,,) = FACTORY.storylines(idF1);
+        (,, uint24 pc,,) = FACTORY.storylines(idF1);
         require(pc == 2, "F4: plotCount should be 2");
         console.log("[F4] chainPlot with empty title        PASS  plotCount=%d", pc);
         scenariosPassed++;
 
         // F5: Buy then sell same amount - refund < cost due to royalties
-        (, address tokenF1,,,,) = FACTORY.storylines(idF1);
+        (, address tokenF1,,,) = FACTORY.storylines(idF1);
         IERC20Extended storyTokenF1 = IERC20Extended(tokenF1);
         storyTokenF1.approve(address(BOND), type(uint256).max);
 

--- a/src/StoryFactory.sol
+++ b/src/StoryFactory.sol
@@ -13,12 +13,11 @@ contract StoryFactory {
     // -----------------------------------------------------------------------
 
     struct Storyline {
-        address writer; // sole author, royalty recipient
-        address token; // storyline token address on Mint Club
-        uint256 plotCount; // total plots chained
-        uint256 lastPlotTime; // timestamp of last plot (for deadline)
-        bool hasDeadline; // whether 168h (7-day) deadline is enabled
-        bool sunset; // true if deadline expired
+        address writer; // slot 1: sole author, royalty recipient (160 bits)
+        address token; // slot 2: storyline token address on Mint Club (160 bits)
+        uint24 plotCount; // slot 2: total plots chained (+24 = 184 bits)
+        uint40 lastPlotTime; // slot 2: timestamp of last plot (+40 = 224 bits)
+        bool hasDeadline; // slot 2: whether 168h deadline is enabled (+8 = 232 bits)
     }
 
     // -----------------------------------------------------------------------
@@ -50,8 +49,8 @@ contract StoryFactory {
     // Constants
     // -----------------------------------------------------------------------
 
-    uint16 public constant MINT_ROYALTY = 500; // 5% (basis points, base 10000)
-    uint16 public constant BURN_ROYALTY = 500; // 5%
+    uint16 public constant MINT_ROYALTY = 100; // 1% (basis points, base 10000)
+    uint16 public constant BURN_ROYALTY = 100; // 1%
 
     // -----------------------------------------------------------------------
     // State
@@ -133,9 +132,8 @@ contract StoryFactory {
             writer: msg.sender,
             token: tokenAddress,
             plotCount: 1,
-            lastPlotTime: block.timestamp,
-            hasDeadline: hasDeadline,
-            sunset: false
+            lastPlotTime: uint40(block.timestamp),
+            hasDeadline: hasDeadline
         });
 
         // 4. Emit events
@@ -158,16 +156,27 @@ contract StoryFactory {
         Storyline storage s = storylines[storylineId];
         require(msg.sender == s.writer, "Not writer");
         require(bytes(contentCID).length >= 46 && bytes(contentCID).length <= 100, "Invalid CID");
-        require(!s.sunset, "Storyline sunset");
         if (s.hasDeadline) {
-            require(block.timestamp <= s.lastPlotTime + 168 hours, "Deadline passed");
+            require(block.timestamp <= uint256(s.lastPlotTime) + 168 hours, "Deadline passed");
         }
 
         uint256 plotIndex = s.plotCount; // genesis = 0, so first chain = 1
         s.plotCount++;
-        s.lastPlotTime = block.timestamp;
+        s.lastPlotTime = uint40(block.timestamp);
 
         emit PlotChained(storylineId, plotIndex, msg.sender, title, contentCID, contentHash);
+    }
+
+    // -----------------------------------------------------------------------
+    // hasSunset
+    // -----------------------------------------------------------------------
+
+    /// @notice Check if a storyline's deadline has expired
+    /// @param storylineId The storyline to check
+    /// @return True if the storyline has a deadline and it has passed
+    function hasSunset(uint256 storylineId) external view returns (bool) {
+        Storyline storage s = storylines[storylineId];
+        return s.hasDeadline && block.timestamp > uint256(s.lastPlotTime) + 168 hours;
     }
 
     // -----------------------------------------------------------------------

--- a/test/StoryFactory.t.sol
+++ b/test/StoryFactory.t.sol
@@ -123,14 +123,12 @@ contract StoryFactoryTest is Test {
         assertEq(id, 1);
         assertEq(factory.storylineCount(), 1);
 
-        (address w, address tok, uint256 plotCount, uint256 lastPlot, bool deadline, bool sunset) =
-            factory.storylines(1);
+        (address w, address tok, uint24 plotCount, uint40 lastPlot, bool deadline) = factory.storylines(1);
         assertEq(w, writer);
         assertTrue(tok != address(0));
         assertEq(plotCount, 1);
-        assertEq(lastPlot, block.timestamp);
+        assertEq(lastPlot, uint40(block.timestamp));
         assertFalse(deadline);
-        assertFalse(sunset);
 
         // Bond was called
         assertEq(bond.createCount(), 1);
@@ -201,7 +199,7 @@ contract StoryFactoryTest is Test {
         vm.prank(writer);
         factory.chainPlot(id, "Chapter 2", cid2, hash2);
 
-        (,, uint256 plotCount,,,) = factory.storylines(id);
+        (,, uint24 plotCount,,) = factory.storylines(id);
         assertEq(plotCount, 2);
     }
 
@@ -263,31 +261,57 @@ contract StoryFactoryTest is Test {
         vm.prank(writer);
         factory.chainPlot(id, "Late Chapter", VALID_CID, FAKE_HASH);
 
-        (,, uint256 plotCount,,,) = factory.storylines(id);
+        (,, uint24 plotCount,,) = factory.storylines(id);
         assertEq(plotCount, 2);
     }
 
-    function test_chainPlot_revert_sunset() public {
+    // ===================================================================
+    // hasSunset
+    // ===================================================================
+
+    function test_hasSunset_false_noDeadline() public {
         vm.prank(writer);
         uint256 id = factory.createStoryline("Story", VALID_CID, FAKE_HASH, false);
 
-        // Storyline struct is at mapping slot: keccak256(abi.encode(id, 2))
-        // where 2 is the storage slot of `storylines` mapping.
-        // Struct layout: writer(slot+0), token(slot+1), plotCount(slot+2),
-        //   lastPlotTime(slot+3), hasDeadline+sunset packed in slot+4
-        // hasDeadline is at byte 0, sunset is at byte 1
-        bytes32 baseSlot = keccak256(abi.encode(id, uint256(2)));
-        bytes32 flagsSlot = bytes32(uint256(baseSlot) + 4);
+        vm.warp(block.timestamp + 365 days);
+        assertFalse(factory.hasSunset(id));
+    }
 
-        // Read current value and set sunset bit (byte 1 = offset 1 from right)
-        bytes32 current = vm.load(address(factory), flagsSlot);
-        // sunset is the second bool in the packed slot — set byte at offset 1
-        bytes32 withSunset = current | bytes32(uint256(1) << 8);
-        vm.store(address(factory), flagsSlot, withSunset);
-
+    function test_hasSunset_false_withinDeadline() public {
         vm.prank(writer);
-        vm.expectRevert("Storyline sunset");
+        uint256 id = factory.createStoryline("Story", VALID_CID, FAKE_HASH, true);
+
+        vm.warp(block.timestamp + 167 hours);
+        assertFalse(factory.hasSunset(id));
+    }
+
+    function test_hasSunset_true_deadlineExpired() public {
+        vm.prank(writer);
+        uint256 id = factory.createStoryline("Story", VALID_CID, FAKE_HASH, true);
+
+        vm.warp(block.timestamp + 168 hours + 1);
+        assertTrue(factory.hasSunset(id));
+    }
+
+    function test_hasSunset_resets_afterChainPlot() public {
+        vm.prank(writer);
+        uint256 id = factory.createStoryline("Story", VALID_CID, FAKE_HASH, true);
+
+        // Almost expired
+        vm.warp(block.timestamp + 167 hours);
+        assertFalse(factory.hasSunset(id));
+
+        // Chain a plot — resets the deadline
+        vm.prank(writer);
         factory.chainPlot(id, "Chapter 2", VALID_CID, FAKE_HASH);
+
+        // 167 hours after the new plot — still within deadline
+        vm.warp(block.timestamp + 167 hours);
+        assertFalse(factory.hasSunset(id));
+
+        // 169 hours after the new plot — expired
+        vm.warp(block.timestamp + 2 hours);
+        assertTrue(factory.hasSunset(id));
     }
 
     // ===================================================================
@@ -338,5 +362,14 @@ contract StoryFactoryTest is Test {
         vm.prank(other);
         vm.expectRevert("Insufficient allowance");
         factory.donate(id, 100e18);
+    }
+
+    // ===================================================================
+    // Royalty constants
+    // ===================================================================
+
+    function test_royaltyConstants() public view {
+        assertEq(factory.MINT_ROYALTY(), 100); // 1%
+        assertEq(factory.BURN_ROYALTY(), 100); // 1%
     }
 }


### PR DESCRIPTION
## Summary
- **Royalty reduction**: 500 (5%) → 100 (1%) basis points for both mint and burn
- **Remove sunset**: deleted `bool sunset` from Storyline struct; added `hasSunset()` view that derives from `hasDeadline && block.timestamp > lastPlotTime + 168h`
- **Struct optimization**: 5 slots → 2 slots — `plotCount` uint256→uint24, `lastPlotTime` uint256→uint40, packed into slot 2 with `token` and `hasDeadline`
- Removed `require(!s.sunset, "Storyline sunset")` from `chainPlot()` — the existing deadline check covers this
- Updated E2E scripts for 5-field struct destructuring

## Test plan
- [x] All 32 tests pass (22 StoryFactory + 10 DeployBase)
- [x] 4 new `hasSunset()` tests: no deadline, within deadline, expired, reset after chainPlot
- [x] 1 new `royaltyConstants()` test: asserts MINT_ROYALTY=100, BURN_ROYALTY=100
- [x] `forge fmt --check` clean

Fixes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)