### PR TITLE
[#42] Add input validations: title, hash, zero-address, array cap

### DIFF
--- a/script/E2ETest.s.sol
+++ b/script/E2ETest.s.sol
@@ -407,11 +407,11 @@ contract E2ETest is Script {
         console.log("[F2] CID exact max (100 chars)         PASS  storylineId=%d", idF2);
         scenariosPassed++;
 
-        // F4: chainPlot with empty title (title not validated in chainPlot) — use F1's storyline
-        FACTORY.chainPlot(idF1, "", CID_46, HASH_B);
+        // F4: chainPlot to F1 storyline (verifies cross-storyline chaining)
+        FACTORY.chainPlot(idF1, "F1 Chapter 2", CID_46, HASH_B);
         (,, uint24 pc,,) = FACTORY.storylines(idF1);
         require(pc == 2, "F4: plotCount should be 2");
-        console.log("[F4] chainPlot with empty title        PASS  plotCount=%d", pc);
+        console.log("[F4] chainPlot to F1 storyline         PASS  plotCount=%d", pc);
         scenariosPassed++;
 
         // F5: Buy then sell same amount - refund < cost due to royalties

--- a/src/StoryFactory.sol
+++ b/src/StoryFactory.sol
@@ -78,8 +78,11 @@ contract StoryFactory {
         uint128[] memory _stepRanges,
         uint128[] memory _stepPrices
     ) {
+        require(_bond != address(0), "Zero bond address");
+        require(_plotToken != address(0), "Zero token address");
         require(_stepRanges.length == _stepPrices.length, "Step arrays length mismatch");
         require(_stepRanges.length > 0, "Empty step arrays");
+        require(_stepRanges.length <= 1000, "Too many steps");
 
         BOND = IMCV2_Bond(_bond);
         PLOT_TOKEN = IERC20(_plotToken);
@@ -105,6 +108,7 @@ contract StoryFactory {
     {
         require(bytes(title).length > 0, "Empty title");
         require(bytes(openingCID).length >= 46 && bytes(openingCID).length <= 100, "Invalid CID");
+        require(openingHash != bytes32(0), "Empty hash");
 
         storylineId = ++storylineCount;
 
@@ -155,7 +159,9 @@ contract StoryFactory {
     {
         Storyline storage s = storylines[storylineId];
         require(msg.sender == s.writer, "Not writer");
+        require(bytes(title).length > 0, "Empty title");
         require(bytes(contentCID).length >= 46 && bytes(contentCID).length <= 100, "Invalid CID");
+        require(contentHash != bytes32(0), "Empty hash");
         if (s.hasDeadline) {
             require(block.timestamp <= uint256(s.lastPlotTime) + 168 hours, "Deadline passed");
         }

--- a/test/StoryFactory.t.sol
+++ b/test/StoryFactory.t.sol
@@ -372,4 +372,64 @@ contract StoryFactoryTest is Test {
         assertEq(factory.MINT_ROYALTY(), 100); // 1%
         assertEq(factory.BURN_ROYALTY(), 100); // 1%
     }
+
+    // ===================================================================
+    // Input validations (#42)
+    // ===================================================================
+
+    function test_chainPlot_revert_emptyTitle() public {
+        vm.prank(writer);
+        uint256 id = factory.createStoryline("Story", VALID_CID, FAKE_HASH, false);
+
+        vm.prank(writer);
+        vm.expectRevert("Empty title");
+        factory.chainPlot(id, "", VALID_CID, FAKE_HASH);
+    }
+
+    function test_createStoryline_revert_emptyHash() public {
+        vm.prank(writer);
+        vm.expectRevert("Empty hash");
+        factory.createStoryline("Title", VALID_CID, bytes32(0), false);
+    }
+
+    function test_chainPlot_revert_emptyHash() public {
+        vm.prank(writer);
+        uint256 id = factory.createStoryline("Story", VALID_CID, FAKE_HASH, false);
+
+        vm.prank(writer);
+        vm.expectRevert("Empty hash");
+        factory.chainPlot(id, "Chapter 2", VALID_CID, bytes32(0));
+    }
+
+    function test_constructor_revert_zeroBond() public {
+        uint128[] memory ranges = new uint128[](1);
+        ranges[0] = 1e18;
+        uint128[] memory prices = new uint128[](1);
+        prices[0] = 1e15;
+
+        vm.expectRevert("Zero bond address");
+        new StoryFactory(address(0), address(plot), 1e18, ranges, prices);
+    }
+
+    function test_constructor_revert_zeroToken() public {
+        uint128[] memory ranges = new uint128[](1);
+        ranges[0] = 1e18;
+        uint128[] memory prices = new uint128[](1);
+        prices[0] = 1e15;
+
+        vm.expectRevert("Zero token address");
+        new StoryFactory(address(bond), address(0), 1e18, ranges, prices);
+    }
+
+    function test_constructor_revert_tooManySteps() public {
+        uint128[] memory ranges = new uint128[](1001);
+        uint128[] memory prices = new uint128[](1001);
+        for (uint256 i = 0; i < 1001; i++) {
+            ranges[i] = uint128(i + 1);
+            prices[i] = uint128(i + 1);
+        }
+
+        vm.expectRevert("Too many steps");
+        new StoryFactory(address(bond), address(plot), 1e18, ranges, prices);
+    }
 }


### PR DESCRIPTION
## Summary
- `chainPlot()`: require non-empty title (`"Empty title"`)
- `createStoryline()` + `chainPlot()`: require non-zero content hash (`"Empty hash"`)
- Constructor: require non-zero `_bond` and `_plotToken` addresses
- Constructor: cap `stepRanges`/`stepPrices` at 1000 entries (`"Too many steps"`)
- Updated E2E F4 to use non-empty title (previously tested empty title as happy path)

## Test plan
- [x] All 38 tests pass (28 StoryFactory + 10 DeployBase)
- [x] 6 new revert tests covering all validation paths
- [x] `forge fmt --check` clean

Fixes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)