### PR TITLE
[#45] Update E2E scripts for post-#38 contract changes

### DIFF
--- a/script/E2ETest.s.sol
+++ b/script/E2ETest.s.sol
@@ -444,13 +444,7 @@ contract E2ETest is Script {
         FACTORY.updateCurve(newRanges, newPrices);
         console.log("[F6] updateCurve by owner              PASS");
 
-        uint256 idF6 = FACTORY.createStoryline{value: creationFee}("Updated Curve Story", CID_46, HASH_A, false);
-        require(idF6 > 0, "F6: failed to create with new curve");
-        console.log("[F6] Create after updateCurve           PASS  storylineId=%d", idF6);
-        scenariosPassed += 2;
-
-        // Restore original curve (500 steps) to leave contract in clean state
-        // Not practical in broadcast — skip restore. The curve is now 2-step.
+        uint256 idF6 = _verifyF6();
 
         // Serialize edge case storyline IDs
         string memory fKey = "edgeCasesF";
@@ -459,5 +453,26 @@ contract E2ETest is Script {
         vm.serializeUint(fKey, "f2StorylineId", idF2);
         string memory fJson = vm.serializeUint(fKey, "f6StorylineId", idF6);
         vm.serializeString(resultsJson, "edgeCasesF", fJson);
+    }
+
+    function _verifyF6() internal returns (uint256 idF6) {
+        idF6 = FACTORY.createStoryline{value: creationFee}("Updated Curve Story", CID_46, HASH_A, false);
+        require(idF6 > 0, "F6: failed to create with new curve");
+
+        // Prove the new curve is used: buy 1 token, cost should reflect new price (2e15)
+        (, address tokenF6,,,) = FACTORY.storylines(idF6);
+        IERC20Extended storyTokenF6 = IERC20Extended(tokenF6);
+        storyTokenF6.approve(address(BOND), type(uint256).max);
+        uint256 balBefore = PL_TEST.balanceOf(deployer);
+        BOND.mint(tokenF6, 1e18, type(uint256).max, deployer);
+        uint256 f6Cost = balBefore - PL_TEST.balanceOf(deployer);
+        // New curve first step is 2e15 + 1% royalty. Original was 1e15 + 1%.
+        // So cost should be > 1.5e15 (proving new curve was applied)
+        require(f6Cost > 1.5e15, "F6: cost too low, new curve not applied");
+        console.log("[F6] Create+buy after updateCurve      PASS  cost=%d (new curve)", f6Cost);
+        scenariosPassed += 2;
+
+        // Sell back to clean up
+        BOND.burn(tokenF6, 1e18, 0, deployer);
     }
 }

--- a/script/E2ETestReverts.s.sol
+++ b/script/E2ETestReverts.s.sol
@@ -204,23 +204,12 @@ contract E2ETestReverts is Script {
         console.log("[G1] hasSunset (no deadline) = false   PASS");
         scenariosPassed++;
 
-        // G2: hasSunset on expired deadline storyline
-        // Read storylineA2 which has hasDeadline from e2e-results.json
-        uint256 idA2 = vm.parseJsonUint(json, ".storylineA2.storylineId");
-        bool a2HasDeadline = vm.parseJsonBool(json, ".storylineA2.hasDeadline");
-        if (!a2HasDeadline) {
-            // A2 has no deadline — hasSunset should be false even after warp
-            vm.warp(block.timestamp + 365 days);
-            bool sunset2 = FACTORY.hasSunset(idA2);
-            require(!sunset2, "G2: hasSunset should be false without deadline even after warp");
-            console.log("[G2] hasSunset (no deadline, warped)    PASS");
-        } else {
-            // A2 has deadline — warp past it
-            vm.warp(block.timestamp + 169 hours);
-            bool sunset2 = FACTORY.hasSunset(idA2);
-            require(sunset2, "G2: hasSunset should be true after deadline");
-            console.log("[G2] hasSunset (expired deadline)       PASS");
-        }
+        // G2: hasSunset on expired deadline storyline (A1 has hasDeadline=true)
+        // Warp past 168h from the last plot time — hasSunset should return true
+        vm.warp(block.timestamp + 169 hours);
+        bool sunset2 = FACTORY.hasSunset(idA1);
+        require(sunset2, "G2: hasSunset should be true after deadline expired");
+        console.log("[G2] hasSunset (expired deadline)       PASS");
         scenariosPassed++;
 
         // ===== Group H: Constructor validations (simulation only) =====


### PR DESCRIPTION
## Summary
- Update factory address to new deployment (`0x27B4FCf333f29a3865b3B76ea00C955D7b64BD0F`)
- Add 5 new test scenarios to revert script:
  - E10: empty title in chainPlot
  - E11: zero hash in createStoryline
  - E12: zero hash in chainPlot
  - E13: non-owner updateCurve
  - G1: hasSunset view on active storyline
- Revert script now covers 16 scenarios (was 11)

## Test plan
- [x] All 45 unit tests pass
- [x] `forge fmt --check` clean
- [ ] E2E broadcast runs against new deployment
- [ ] E2E revert script passes all 16 scenarios

Fixes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)