### PR TITLE
[#52] Add initialStorylineCount constructor param

### DIFF
--- a/script/DeployBase.s.sol
+++ b/script/DeployBase.s.sol
@@ -24,7 +24,7 @@ contract DeployBase is Script {
         uint256 deployerKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
         vm.startBroadcast(deployerKey);
 
-        StoryFactory factory = new StoryFactory(MCV2_BOND, PL_TEST, MAX_SUPPLY, stepRanges, stepPrices);
+        StoryFactory factory = new StoryFactory(MCV2_BOND, PL_TEST, MAX_SUPPLY, stepRanges, stepPrices, 8);
 
         vm.stopBroadcast();
 

--- a/script/DeployBaseSepolia.s.sol
+++ b/script/DeployBaseSepolia.s.sol
@@ -24,7 +24,7 @@ contract DeployBaseSepolia is Script {
         uint256 deployerKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
         vm.startBroadcast(deployerKey);
 
-        StoryFactory factory = new StoryFactory(MCV2_BOND, PLOT_TOKEN, MAX_SUPPLY, stepRanges, stepPrices);
+        StoryFactory factory = new StoryFactory(MCV2_BOND, PLOT_TOKEN, MAX_SUPPLY, stepRanges, stepPrices, 0);
 
         vm.stopBroadcast();
 

--- a/script/E2ETestReverts.s.sol
+++ b/script/E2ETestReverts.s.sol
@@ -222,7 +222,7 @@ contract E2ETestReverts is Script {
         p1[0] = 1e15;
 
         // H1: Zero bond address
-        try new StoryFactory(address(0), address(1), 1e18, r1, p1) {
+        try new StoryFactory(address(0), address(1), 1e18, r1, p1, 0) {
             revert("H1: should have reverted");
         } catch Error(string memory reason) {
             require(keccak256(bytes(reason)) == keccak256("Zero bond address"), "H1: wrong revert reason");
@@ -231,7 +231,7 @@ contract E2ETestReverts is Script {
         }
 
         // H2: Zero token address
-        try new StoryFactory(address(1), address(0), 1e18, r1, p1) {
+        try new StoryFactory(address(1), address(0), 1e18, r1, p1, 0) {
             revert("H2: should have reverted");
         } catch Error(string memory reason) {
             require(keccak256(bytes(reason)) == keccak256("Zero token address"), "H2: wrong revert reason");
@@ -246,7 +246,7 @@ contract E2ETestReverts is Script {
             bigR[i] = uint128(i + 1);
             bigP[i] = uint128(i + 1);
         }
-        try new StoryFactory(address(1), address(1), 1e18, bigR, bigP) {
+        try new StoryFactory(address(1), address(1), 1e18, bigR, bigP, 0) {
             revert("H3: should have reverted");
         } catch Error(string memory reason) {
             require(keccak256(bytes(reason)) == keccak256("Too many steps"), "H3: wrong revert reason");

--- a/src/StoryFactory.sol
+++ b/src/StoryFactory.sol
@@ -88,7 +88,8 @@ contract StoryFactory {
         address _plotToken,
         uint128 _maxSupply,
         uint128[] memory _stepRanges,
-        uint128[] memory _stepPrices
+        uint128[] memory _stepPrices,
+        uint256 _initialStorylineCount
     ) {
         require(_bond != address(0), "Zero bond address");
         require(_plotToken != address(0), "Zero token address");
@@ -102,6 +103,7 @@ contract StoryFactory {
         owner = msg.sender;
         stepRanges = _stepRanges;
         stepPrices = _stepPrices;
+        storylineCount = _initialStorylineCount;
     }
 
     // -----------------------------------------------------------------------

--- a/test/StoryFactory.t.sol
+++ b/test/StoryFactory.t.sol
@@ -109,7 +109,7 @@ contract StoryFactoryTest is Test {
         prices[0] = 1e15;
         prices[1] = 1e18;
 
-        factory = new StoryFactory(address(bond), address(plot), 1_000_000e18, ranges, prices);
+        factory = new StoryFactory(address(bond), address(plot), 1_000_000e18, ranges, prices, 0);
     }
 
     // ===================================================================
@@ -408,7 +408,7 @@ contract StoryFactoryTest is Test {
         prices[0] = 1e15;
 
         vm.expectRevert("Zero bond address");
-        new StoryFactory(address(0), address(plot), 1e18, ranges, prices);
+        new StoryFactory(address(0), address(plot), 1e18, ranges, prices, 0);
     }
 
     function test_constructor_revert_zeroToken() public {
@@ -418,7 +418,7 @@ contract StoryFactoryTest is Test {
         prices[0] = 1e15;
 
         vm.expectRevert("Zero token address");
-        new StoryFactory(address(bond), address(0), 1e18, ranges, prices);
+        new StoryFactory(address(bond), address(0), 1e18, ranges, prices, 0);
     }
 
     function test_constructor_revert_tooManySteps() public {
@@ -430,7 +430,7 @@ contract StoryFactoryTest is Test {
         }
 
         vm.expectRevert("Too many steps");
-        new StoryFactory(address(bond), address(plot), 1e18, ranges, prices);
+        new StoryFactory(address(bond), address(plot), 1e18, ranges, prices, 0);
     }
 
     // ===================================================================


### PR DESCRIPTION
## Summary
- Add `initialStorylineCount` constructor param to `StoryFactory` so the counter can skip past symbols already registered on the shared MCV2_Bond (PL-1 through PL-8)
- `DeployBase.s.sol` passes `8`; all other deploy scripts and tests pass `0`
- All 45 unit tests pass

Fixes realproject7/plotlink-contracts#52

## Test plan
- [x] `forge build` — compiles cleanly
- [x] `forge test -vv` — 45/45 pass
- [ ] After merge: redeploy to Base mainnet, update factory address in E2E scripts, run E2E

🤖 Generated with [Claude Code](https://claude.com/claude-code)