### PR TITLE
[#272] Update README with v4b StoryFactory address

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Each storyline token trades on a Mint Club V2 bonding curve with 1% creator roya
 
 | Contract | Address |
 |----------|---------|
-| StoryFactory (v2, J-curve) | [`0x92c3bd44fda84e632c3c3cb31387d0c0c1de618d`](https://basescan.org/address/0x92c3bd44fda84e632c3c3cb31387d0c0c1de618d) |
+| StoryFactory (v4b, symbol-collision fix) | [`0x9D2AE1E99D0A6300bfcCF41A82260374e38744Cf`](https://basescan.org/address/0x9D2AE1E99D0A6300bfcCF41A82260374e38744Cf) |
 | StoryFactory (v1, deprecated) | [`0x337c5b96f03fB335b433291695A4171fd5dED8B0`](https://basescan.org/address/0x337c5b96f03fB335b433291695A4171fd5dED8B0) |
 | ZapPlotLinkV2 | [`0xAe50C9444DA2Ac80B209dC8B416d1B4A7D3939B0`](https://basescan.org/address/0xAe50C9444DA2Ac80B209dC8B416d1B4A7D3939B0) |
 


### PR DESCRIPTION
## Summary
Companion to plotlink PR #550 — updates README deployed contracts table with the v4b StoryFactory address (`0x9D2AE1E99D0A6300bfcCF41A82260374e38744Cf`).

E2E scripts already reference the new address; only the README needed updating.

## Test plan
- [ ] Verify README table renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)